### PR TITLE
Add Docker Hub publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,28 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: vinaykudari/stocklerts:latest

--- a/README.md
+++ b/README.md
@@ -108,7 +108,16 @@ gunicorn -b 0.0.0.0:5005 webhook_handler:app
  docker compose build 
  # make sure you sent the env vars before you run this
 docker compose up
- ```
+```
+
+### Docker Hub Deployment
+
+A GitHub Actions workflow automatically builds and publishes a Docker image
+whenever changes are merged into the `main` branch. Pull the latest image with:
+
+```bash
+docker pull vinaykudari/stocklerts:latest
+```
 
 ## CI/CD setup to restart the server when the codebase updates
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -7,6 +7,12 @@ from datetime import timedelta, date
 from app.price_tracking.tracker import check_stock_price_change
 
 
+@pytest.fixture(autouse=True)
+def mock_market_open_and_heartbeat(mocker):
+    mocker.patch('app.price_tracking.tracker.is_market_open', return_value=True)
+    mocker.patch('requests.get')
+
+
 @pytest.fixture
 def mock_finnhub_client(mocker):
     return mocker.Mock()


### PR DESCRIPTION
## Summary
- patch tests to ensure `check_stock_price_change` can run without network
- add a GitHub workflow that publishes the Docker image to Docker Hub on merges to main
- document Docker Hub deployment instructions

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a69589484832db171721b688a560e