### PR TITLE
Add /health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,14 @@ A Python-based stock alerting service that monitors prices (One symbol/sec) usin
 gunicorn -b 0.0.0.0:5005 webhook_handler:app
  ```
 - Start the app server
- ```bash
- poetry run python -m app.main
- ```
+```bash
+poetry run python -m app.main
+```
+- A health check endpoint is available once the app server starts:
+```bash
+curl http://localhost:8000/health
+```
+This returns `{"status": "OK"}` when the service is running.
 
 - Alternatively, use docker
  ```bash

--- a/app/health_server.py
+++ b/app/health_server.py
@@ -1,0 +1,27 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class HealthRequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # type: ignore[override]
+        if self.path == '/health':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'status': 'OK'}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args) -> None:  # noqa: D401
+        """Silence default logging."""
+        return
+
+
+def start_health_server(port: int = 8000) -> HTTPServer:
+    """Start a background HTTP server exposing the /health endpoint."""
+    server = HTTPServer(('0.0.0.0', port), HealthRequestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ import logging
 from app.scheduler.job_scheduler import start_scheduler
 from app.database.db_manager import DBManager
 from app.utils.helper import load_config, setup_logging
+from app.health_server import start_health_server
 
 
 def main() -> None:
@@ -35,6 +36,8 @@ def main() -> None:
         max_notifications,
         max_quote_calls_per_min
     )
+    # Start lightweight health check server in the background
+    start_health_server()
 
     try:
         import time

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,13 @@
+import requests
+from app.health_server import start_health_server
+
+
+def test_health_endpoint(tmp_path):
+    server = start_health_server(port=0)
+    port = server.server_address[1]
+    try:
+        resp = requests.get(f'http://127.0.0.1:{port}/health')
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "OK"}
+    finally:
+        server.shutdown()


### PR DESCRIPTION
## Summary
- create lightweight HTTP health server
- start health server from `app.main`
- document health endpoint in README
- test the new /health endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6d7efae4832d94e08c46366bada4