### PR TITLE
Fix daily counter reset logic with datetime input

### DIFF
--- a/app/database/db_manager.py
+++ b/app/database/db_manager.py
@@ -18,7 +18,14 @@ class User(Base):
     last_notification_date = Column(DateTime, nullable=True)
 
     def reset_daily_count(self):
-        if not self.last_notification_date or self.last_notification_date < date.today():
+        last_date = None
+        if self.last_notification_date:
+            if isinstance(self.last_notification_date, datetime.datetime):
+                last_date = self.last_notification_date.date()
+            else:
+                last_date = self.last_notification_date
+
+        if not last_date or last_date < date.today():
             self.notification_count = 0
             self.last_notification_date = date.today()
 

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+from datetime import datetime, timedelta, date
+
+from app.database.db_manager import DBManager, User
+
+
+def create_temp_db():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    url = f"sqlite:///{path}"
+    return DBManager(db_url=url), path
+
+
+def test_reset_daily_counters_resets_with_datetime_date():
+    db, path = create_temp_db()
+    try:
+        with db.Session() as session:
+            user = User(notification_count=5, last_notification_date=datetime.now() - timedelta(days=1))
+            session.add(user)
+            session.commit()
+
+        db.reset_daily_counters()
+
+        with db.Session() as session:
+            user_from_db = session.query(User).first()
+            assert user_from_db.notification_count == 0
+            assert user_from_db.last_notification_date.date() == date.today()
+    finally:
+        os.remove(path)
+
+
+def test_reset_daily_counters_same_day_no_reset():
+    db, path = create_temp_db()
+    try:
+        with db.Session() as session:
+            user = User(notification_count=5, last_notification_date=datetime.now())
+            session.add(user)
+            session.commit()
+
+        db.reset_daily_counters()
+
+        with db.Session() as session:
+            user_from_db = session.query(User).first()
+            assert user_from_db.notification_count == 5
+            assert user_from_db.last_notification_date.date() == date.today()
+    finally:
+        os.remove(path)


### PR DESCRIPTION
## Summary
- handle `datetime` vs `date` comparison in `reset_daily_count`
- add regression tests for `DBManager.reset_daily_counters`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5eb57664832db4473ac119a4962f