### PR TITLE
Add manual daily recommendations trigger

### DIFF
--- a/app/health_server.py
+++ b/app/health_server.py
@@ -1,6 +1,11 @@
 import json
+import os
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import finnhub
+
+from app.recommendations.daily_recommender import get_daily_recommendations
 
 
 class HealthRequestHandler(BaseHTTPRequestHandler):
@@ -14,14 +19,36 @@ class HealthRequestHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
+    def do_POST(self) -> None:  # type: ignore[override]
+        if self.path == '/recommendations':
+            client = getattr(self.server, 'finnhub_client', None)
+            if client is None:
+                api_key = os.getenv('FINNHUB_API_KEY')
+                client = finnhub.Client(api_key=api_key) if api_key else None
+
+            if client is None:
+                self.send_response(500)
+                self.end_headers()
+                return
+
+            get_daily_recommendations(client)
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'status': 'OK'}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
     def log_message(self, format: str, *args) -> None:  # noqa: D401
         """Silence default logging."""
         return
 
 
-def start_health_server(port: int = 8000) -> HTTPServer:
+def start_health_server(port: int = 8000, finnhub_client: finnhub.Client | None = None) -> HTTPServer:
     """Start a background HTTP server exposing the /health endpoint."""
     server = HTTPServer(('0.0.0.0', port), HealthRequestHandler)
+    server.finnhub_client = finnhub_client  # type: ignore[attr-defined]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -11,3 +11,17 @@ def test_health_endpoint(tmp_path):
         assert resp.json() == {"status": "OK"}
     finally:
         server.shutdown()
+
+
+def test_recommendations_endpoint(mocker):
+    mock_func = mocker.patch('app.health_server.get_daily_recommendations')
+    dummy_client = object()
+    server = start_health_server(port=0, finnhub_client=dummy_client)
+    port = server.server_address[1]
+    try:
+        resp = requests.post(f'http://127.0.0.1:{port}/recommendations')
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "OK"}
+        mock_func.assert_called_once_with(dummy_client)
+    finally:
+        server.shutdown()


### PR DESCRIPTION
## Summary
- add POST `/recommendations` endpoint to health server
- allow `start_health_server` to inject a finnhub client
- test triggering of the new endpoint

## Testing
- `pip install '.[dev]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685075b828ec832db3ab823f33037cc5