### PR TITLE
Log daily performance to repo

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'resources/*.csv'
 
 jobs:
   build-and-push:

--- a/app/recommendations/daily_recommender.py
+++ b/app/recommendations/daily_recommender.py
@@ -1,5 +1,8 @@
 import logging
-from typing import List, Dict
+import csv
+import subprocess
+from datetime import datetime
+from typing import List, Dict, Optional
 
 import re
 import os
@@ -8,14 +11,20 @@ import requests
 from pathlib import Path
 
 from app.alerts.notifier import send_notification
-from app.utils.helper import load_config
+from app.utils.helper import load_config, MARKET_TIMEZONE
 
 PROMPT_PATH = Path(__file__).resolve().parents[2] / 'resources' / 'daily_prompt.txt'
+BEST_PROMPT_PATH = Path(__file__).resolve().parents[2] / 'resources' / 'best_performers_prompt.txt'
+PERF_LOG_PATH = Path(__file__).resolve().parents[2] / 'resources' / 'daily_performance.csv'
+BEST_PERF_PATH = Path(__file__).resolve().parents[2] / 'resources' / 'best_daily_performers.csv'
 
 config = load_config('config.yaml')
 USER_IDS = {account['user_id'] for account in config['alertzy']['accounts']}
 
 daily_recommendations: List[Dict[str, float]] = []
+# commit hash of the prompt file used when generating today's recommendations
+prompt_commit_id: str | None = None
+best_prompt_commit_id: str | None = None
 
 
 def _load_prompt() -> str:
@@ -28,6 +37,157 @@ def _load_prompt() -> str:
 
 
 PROMPT = _load_prompt()
+
+
+def _load_best_prompt() -> str:
+    try:
+        with open(BEST_PROMPT_PATH, 'r') as f:
+            return f.read()
+    except Exception as e:
+        logging.error(f"Failed to load best performers prompt: {e}")
+        return ""
+
+
+BEST_PROMPT = _load_best_prompt()
+
+
+def _get_prompt_commit_id() -> str:
+    """Return the latest git commit hash for the prompt file."""
+    try:
+        commit = subprocess.check_output(
+            ['git', 'log', '-1', '--pretty=format:%H', str(PROMPT_PATH)]
+        )
+        return commit.decode().strip()
+    except Exception as e:
+        logging.error(f"Failed to get prompt commit id: {e}")
+        return ""
+
+
+def _get_best_prompt_commit_id() -> str:
+    """Return commit hash for the best performers prompt file."""
+    try:
+        commit = subprocess.check_output(
+            ['git', 'log', '-1', '--pretty=format:%H', str(BEST_PROMPT_PATH)]
+        )
+        return commit.decode().strip()
+    except Exception as e:
+        logging.error(f"Failed to get best prompt commit id: {e}")
+        return ""
+
+
+def _get_market_pct(client: finnhub.Client) -> Optional[float]:
+    """Return today's percentage change for the US market via SPY ETF."""
+    try:
+        quote = client.quote('SPY')
+        open_price = quote.get('o')
+        close_price = quote.get('c')
+        if open_price:
+            return (close_price - open_price) / open_price * 100
+    except Exception as e:
+        logging.error(f"Failed to fetch market performance: {e}")
+    return None
+
+
+def _is_weekday() -> bool:
+    return datetime.now(MARKET_TIMEZONE).weekday() < 5
+
+
+def _log_daily_performance(recs: List[Dict[str, float]], market_pct: Optional[float]) -> None:
+    """Append daily performance data to the CSV log and commit the change."""
+    date_str = datetime.utcnow().strftime('%Y-%m-%d')
+    commit_id = prompt_commit_id or _get_prompt_commit_id()
+
+    row: List[str] = [date_str, commit_id]
+    pct_values: List[float] = []
+    for idx in range(5):
+        rec = recs[idx] if idx < len(recs) else {}
+        symbol = rec.get('symbol', '')
+        pct = rec.get('pct')
+        reason = rec.get('reason', '')
+        row.extend([symbol, f"{pct:+.2f}" if isinstance(pct, float) else ""])
+        if idx < 2:
+            row.append(reason)
+        if isinstance(pct, float):
+            pct_values.append(pct)
+
+    avg_pct = sum(pct_values) / len(pct_values) if pct_values else None
+    row.append(f"{avg_pct:+.2f}" if isinstance(avg_pct, float) else "")
+    row.append(f"{market_pct:+.2f}" if isinstance(market_pct, float) else "")
+
+    file_exists = PERF_LOG_PATH.exists()
+    try:
+        with open(PERF_LOG_PATH, 'a', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            if not file_exists:
+                header = ['date', 'commit_id',
+                          'ticker1', 'growth1', 'reason1',
+                          'ticker2', 'growth2', 'reason2',
+                          'ticker3', 'growth3',
+                          'ticker4', 'growth4',
+                          'ticker5', 'growth5',
+                          'average_growth', 'market_growth']
+                writer.writerow(header)
+            writer.writerow(row)
+    except Exception as e:
+        logging.error(f"Failed to write performance log: {e}")
+        return
+
+    try:
+        subprocess.run(['git', 'add', str(PERF_LOG_PATH)], check=True)
+        subprocess.run(
+            ['git', 'commit', '-m', f'Add daily performance {date_str}'],
+            check=True,
+        )
+        subprocess.run(['git', 'push'], check=True)
+    except Exception as e:
+        logging.error(f"Failed to commit performance log: {e}")
+
+
+def _log_best_performers(recs: List[Dict[str, float]]) -> None:
+    """Append end-of-day best performers data to CSV and commit."""
+    date_str = datetime.utcnow().strftime('%Y-%m-%d')
+    commit_id = best_prompt_commit_id or _get_best_prompt_commit_id()
+
+    row: List[str] = [date_str, commit_id]
+    for idx in range(5):
+        rec = recs[idx] if idx < len(recs) else {}
+        symbol = rec.get('symbol', '')
+        pct = rec.get('pct')
+        reason = rec.get('reason', '')
+        row.extend([
+            symbol,
+            f"{pct:+.2f}" if isinstance(pct, float) else "",
+            reason,
+        ])
+
+    file_exists = BEST_PERF_PATH.exists()
+    try:
+        with open(BEST_PERF_PATH, 'a', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            if not file_exists:
+                header = [
+                    'date', 'commit_id',
+                    'ticker1', 'growth1', 'reason1',
+                    'ticker2', 'growth2', 'reason2',
+                    'ticker3', 'growth3', 'reason3',
+                    'ticker4', 'growth4', 'reason4',
+                    'ticker5', 'growth5', 'reason5',
+                ]
+                writer.writerow(header)
+            writer.writerow(row)
+    except Exception as e:
+        logging.error(f"Failed to write best performers log: {e}")
+        return
+
+    try:
+        subprocess.run(['git', 'add', str(BEST_PERF_PATH)], check=True)
+        subprocess.run(
+            ['git', 'commit', '-m', f'Add best performers {date_str}'],
+            check=True,
+        )
+        subprocess.run(['git', 'push'], check=True)
+    except Exception as e:
+        logging.error(f"Failed to commit best performers log: {e}")
 
 
 def _clean_output(text: str) -> str:
@@ -53,6 +213,29 @@ def parse_recommendations(text: str) -> List[Dict[str, str]]:
         if m:
             symbol, reason = m.groups()
             recs.append({'symbol': symbol, 'reason': reason.strip()})
+        if len(recs) == 5:
+            break
+    return recs
+
+
+def parse_best_performers(text: str) -> List[Dict[str, str]]:
+    text = _clean_output(text)
+    recs = []
+    for line in text.splitlines():
+        line = line.strip()
+        m = re.match(r'^([A-Z]{1,5})\s*-\s*(.+?)\s*-\s*([+-]?\d+(?:\.\d+)?)%$', line)
+        if m:
+            symbol, reason, pct = m.groups()
+        else:
+            m = re.match(r'^([A-Z]{1,5})\s+([+-]?\d+(?:\.\d+)?)%\s*-\s*(.+)$', line)
+            if not m:
+                continue
+            symbol, pct, reason = m.groups()
+        try:
+            pct_val = float(pct)
+        except Exception:
+            continue
+        recs.append({'symbol': symbol, 'reason': reason.strip(), 'pct': pct_val})
         if len(recs) == 5:
             break
     return recs
@@ -85,8 +268,12 @@ def query_perplexity(prompt: str) -> str:
 
 
 def get_daily_recommendations(finnhub_client: finnhub.Client) -> None:
+    if not _is_weekday():
+        return
     logging.warning('Fetching daily stock recommendations from Perplexity')
+    global prompt_commit_id
     prompt = PROMPT
+    prompt_commit_id = _get_prompt_commit_id()
     text = query_perplexity(prompt)
     recs = parse_recommendations(text)
 
@@ -108,7 +295,7 @@ def get_daily_recommendations(finnhub_client: finnhub.Client) -> None:
 
 
 def send_daily_performance(finnhub_client: finnhub.Client) -> None:
-    if not daily_recommendations:
+    if not _is_weekday() or not daily_recommendations:
         return
     lines = []
     for rec in daily_recommendations:
@@ -118,9 +305,38 @@ def send_daily_performance(finnhub_client: finnhub.Client) -> None:
             open_price = rec.get('open_price')
             if open_price:
                 pct = (close_price - open_price) / open_price * 100
+                rec['pct'] = pct
+                rec['close_price'] = close_price
                 lines.append(f"{rec['symbol']}: {pct:+.2f}%")
         except Exception as e:
             logging.error(f"Failed to fetch close price for {rec['symbol']}: {e}")
     if lines:
         message = "Performance of today's picks:\n" + "\n".join(lines)
         send_notification(message, USER_IDS)
+        market_pct = _get_market_pct(finnhub_client)
+        try:
+            _log_daily_performance(daily_recommendations, market_pct)
+        except Exception as e:
+            logging.error(f"Failed to log daily performance: {e}")
+
+        try:
+            get_best_daily_performers(finnhub_client)
+        except Exception as e:
+            logging.error(f"Failed to fetch best performers: {e}")
+
+
+def get_best_daily_performers(finnhub_client: finnhub.Client) -> None:
+    if not _is_weekday():
+        return
+    logging.warning('Fetching top daily performers from Perplexity')
+    global best_prompt_commit_id
+    best_prompt_commit_id = _get_best_prompt_commit_id()
+    text = query_perplexity(BEST_PROMPT)
+    recs = parse_best_performers(text)
+
+    if recs:
+        lines = [f"{r['symbol']}: {r['pct']:+.2f}% - {r['reason']}" for r in recs]
+        message = "Today's best performers:\n" + "\n".join(lines)
+        send_notification(message, USER_IDS)
+        _log_best_performers(recs)
+

--- a/app/scheduler/job_scheduler.py
+++ b/app/scheduler/job_scheduler.py
@@ -12,6 +12,7 @@ from app.price_tracking.tracker import check_stock_price_change
 from app.recommendations.daily_recommender import (
     get_daily_recommendations,
     send_daily_performance,
+    get_best_daily_performers,
 )
 
 
@@ -49,7 +50,7 @@ def start_scheduler(db_manager: DBManager, ticker_config: dict, user_notify_thre
 
     scheduler.add_job(
         func=get_daily_recommendations,
-        trigger=CronTrigger(hour=9, minute=30, timezone='US/Eastern'),
+        trigger=CronTrigger(hour=9, minute=30, timezone='US/Eastern', day_of_week='mon-fri'),
         args=[finnhub_client],
         id='daily_recommendations',
         max_instances=1,
@@ -58,9 +59,18 @@ def start_scheduler(db_manager: DBManager, ticker_config: dict, user_notify_thre
 
     scheduler.add_job(
         func=send_daily_performance,
-        trigger=CronTrigger(hour=16, minute=0, timezone='US/Eastern'),
+        trigger=CronTrigger(hour=16, minute=0, timezone='US/Eastern', day_of_week='mon-fri'),
         args=[finnhub_client],
         id='daily_performance',
+        max_instances=1,
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        func=get_best_daily_performers,
+        trigger=CronTrigger(hour=16, minute=5, timezone='US/Eastern', day_of_week='mon-fri'),
+        args=[finnhub_client],
+        id='best_daily_performers',
         max_instances=1,
         replace_existing=True,
     )

--- a/resources/best_daily_performers.csv
+++ b/resources/best_daily_performers.csv
@@ -1,0 +1,1 @@
+date,commit_id,ticker1,growth1,reason1,ticker2,growth2,reason2,ticker3,growth3,reason3,ticker4,growth4,reason4,ticker5,growth5,reason5

--- a/resources/best_performers_prompt.txt
+++ b/resources/best_performers_prompt.txt
@@ -1,0 +1,3 @@
+List the top 5 US stock performers for today with a short reason and the percentage gain.
+Output format:
+TICKER - reason - XX.X%

--- a/resources/daily_performance.csv
+++ b/resources/daily_performance.csv
@@ -1,0 +1,1 @@
+date,commit_id,ticker1,growth1,reason1,ticker2,growth2,reason2,ticker3,growth3,ticker4,growth4,ticker5,growth5,average_growth,market_growth

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -10,3 +10,12 @@ def test_parse_recommendations_handles_think_block():
         {'symbol': 'MSFT', 'reason': 'reason two'},
     ]
 
+
+def test_parse_best_performers_simple():
+    text = """AAPL - great earnings - 5.2%\nMSFT 4.1% - strong sales"""
+    recs = dr.parse_best_performers(text)
+    assert recs == [
+        {'symbol': 'AAPL', 'reason': 'great earnings', 'pct': 5.2},
+        {'symbol': 'MSFT', 'reason': 'strong sales', 'pct': 4.1},
+    ]
+


### PR DESCRIPTION
## Summary
- track daily performance with commit and push
- add initial `resources/daily_performance.csv` file
- record prompt commit when making recommendations
- ignore unexpected errors during log commit so notifications always go out
- capture reasons for top picks and store SPY market performance
- log top performers each evening using a second prompt
- schedule all daily jobs on weekdays only
- avoid Docker redeploys when only CSV logs change

## Testing
- `pip install -e .`
- `pip install pytest-mock`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b9c24201c832da8bdc28c740b44cd