### PR TITLE
Log performance to Google Sheets

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'resources/*.csv'
 
 jobs:
   build-and-push:

--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ A Python-based stock alerting service that monitors prices (One symbol/sec) usin
 <br><br>
 ![img.png](resources/img.png)
       
-  ```dotenv
-      export ENCRYPT_KEY="<encrypt-key>"
-  ```
+   ```dotenv
+       export ENCRYPT_KEY="<encrypt-key>"
+       # Optional: configure these to log results to Google Sheets
+       export GOOGLE_SERVICE_ACCOUNT='{...}'
+       export DAILY_PERF_SHEET_ID="<google-sheet-id>"
+       export BEST_PERF_SHEET_ID="<google-sheet-id>"
+   ```
    
 4. **Configure Application**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "cryptography>=43.0.1",
     "pytz>=2024.1",
+    "gspread>=6.0.2",
 ]
 
 [project.optional-dependencies]

--- a/resources/best_daily_performers.csv
+++ b/resources/best_daily_performers.csv
@@ -1,1 +1,0 @@
-date,commit_id,ticker1,growth1,reason1,ticker2,growth2,reason2,ticker3,growth3,reason3,ticker4,growth4,reason4,ticker5,growth5,reason5

--- a/resources/daily_performance.csv
+++ b/resources/daily_performance.csv
@@ -1,1 +1,0 @@
-date,commit_id,ticker1,growth1,reason1,ticker2,growth2,reason2,ticker3,growth3,ticker4,growth4,ticker5,growth5,average_growth,market_growth

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -39,3 +39,49 @@ def test_best_performers_endpoint(mocker):
         mock_func.assert_called_once_with(dummy_client)
     finally:
         server.shutdown()
+
+
+def test_best_performers_endpoint_appends_sheet(monkeypatch, mocker):
+    rows: list[list[str]] = []
+
+    class DummyWorksheet:
+        def get_all_values(self):
+            return list(rows)
+
+        def append_row(self, row, value_input_option='USER_ENTERED'):
+            rows.append(row)
+
+    dummy_ws = DummyWorksheet()
+
+    class DummyClient:
+        def open_by_key(self, key):
+            return type('S', (), {'sheet1': dummy_ws})
+
+    def service_account_from_dict(creds):
+        return DummyClient()
+
+    import types, sys
+
+    gspread_dummy = types.SimpleNamespace(service_account_from_dict=service_account_from_dict)
+    monkeypatch.setitem(sys.modules, 'gspread', gspread_dummy)
+    monkeypatch.setenv('GOOGLE_SERVICE_ACCOUNT', '{}')
+    monkeypatch.setenv('BEST_PERF_SHEET_ID', 'sheetid')
+
+    monkeypatch.setattr('app.recommendations.daily_recommender.query_perplexity', lambda prompt: 'AAPL - good\nMSFT - nice')
+    monkeypatch.setattr('app.recommendations.daily_recommender._is_weekday', lambda: True)
+    monkeypatch.setattr('app.recommendations.daily_recommender._get_best_prompt_commit_id', lambda: 'abc')
+    monkeypatch.setattr('app.recommendations.daily_recommender.send_notification', lambda msg, ids: None)
+
+    dummy_client = mocker.Mock()
+    dummy_client.quote.return_value = {'o': 10, 'c': 11}
+
+    server = start_health_server(port=0, finnhub_client=dummy_client)
+    port = server.server_address[1]
+    try:
+        resp = requests.post(f'http://127.0.0.1:{port}/best_performers')
+        assert resp.status_code == 200
+    finally:
+        server.shutdown()
+
+    assert rows[0][0] == 'date'
+    assert len(rows) == 2

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -11,11 +11,3 @@ def test_parse_recommendations_handles_think_block():
     ]
 
 
-def test_parse_best_performers_simple():
-    text = """AAPL - great earnings - 5.2%\nMSFT 4.1% - strong sales"""
-    recs = dr.parse_best_performers(text)
-    assert recs == [
-        {'symbol': 'AAPL', 'reason': 'great earnings', 'pct': 5.2},
-        {'symbol': 'MSFT', 'reason': 'strong sales', 'pct': 4.1},
-    ]
-


### PR DESCRIPTION
## Summary
- remove CSV resources and update workflow
- log daily metrics to Google Sheets instead of CSV files
- use gspread and document new environment variables
- make Google Sheets logging optional
- add headers to Sheets when first writing and test `/best_performers` logging
- parse percentages from Perplexity in best performer flow
- always use `parse_recommendations` for best performer parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e3d1c4034832d8e62738aaed03426